### PR TITLE
change sh to bash

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # This is the version of nixpkgs that introduces an easier way of creating
 # rustc derivations.


### PR DESCRIPTION
In ubuntu 14.04, it can't find `pushd/popd`, hence we need to change from `#!/bin/sh` to `#!/bin/bash`
